### PR TITLE
Add Timestamp class for representing datetime.datetime objects

### DIFF
--- a/asyncqlio/orm/schema/types.py
+++ b/asyncqlio/orm/schema/types.py
@@ -1,4 +1,5 @@
 import abc
+import datetime
 import typing
 
 from asyncqlio.exc import DatabaseException
@@ -15,55 +16,55 @@ class ColumnValidationError(DatabaseException):
 class ColumnType(abc.ABC):
     """
     Implements some underlying mechanisms for a :class:`.Column`.
-    
-    The only method that is required to be implemented on children is :meth:`.ColumnType.sql` - 
-    which is used in CREATE TABLE declarations, etc. :meth:`.ColumnType.on_set`, 
+
+    The only method that is required to be implemented on children is :meth:`.ColumnType.sql` -
+    which is used in CREATE TABLE declarations, etc. :meth:`.ColumnType.on_set`,
     :meth:`.ColumnType.on_get` and so on are not required to be implemented - the defaults will
     work fine.
-    
+
     The ColumnType is responsible for actually loading the data from the row's internal storage
     and to the user code.
-    
+
     .. code-block:: python
-    
+
         # we hate fun
         def on_get(self, row, column):
             return "lol"
-        
+
         ...
-        
+
         # row is a random row object
         # load the `fun` column which has this weird type
         value = row.fun
         print(value)  # "lol", regardless of what was stored in the database.
-    
+
     Accordingly, it is also responsible for storing the data into the row's internal storage.
-    
+
     .. code-block:: python
-        
+
         def on_set(*args, **kwargs):
             return None
-            
+
         row.not_fun = 1
         print(row.not_fun)  # None - no value was stored in the row
-        
+
     To actually insert a value into the row's storage table, use :meth:`.ColumnType.store_value`.
-    Correspondingly, loading a value from the row's storage table can be achieved with 
+    Correspondingly, loading a value from the row's storage table can be achieved with
     :meth:`.ColumnType.load_value`. These functions should be used, as they are guarenteed to work
     across all versions.
-    
+
     Columns will proxy bad attribute accesses from the Column object to this type object - meaning
-    types can implement custom operators, if applicable.  
-    
+    types can implement custom operators, if applicable.
+
     .. code-block:: python
-    
+
         class User(Table):
             id = Column(MyWeirdType())
-            
+
         ...
-        
+
         # MyWeirdType implements `.contains`
-        # the contains call is proxied to (MyWeirdType instance).contains("heck") 
+        # the contains call is proxied to (MyWeirdType instance).contains("heck")
         q = await sess.select(User).where(User.id.contains("heck")).first()
 
     """
@@ -76,7 +77,7 @@ class ColumnType(abc.ABC):
     @abc.abstractmethod
     def sql(self) -> str:
         """
-        :return: The str SQL name of this type. 
+        :return: The str SQL name of this type.
         """
 
     def validate_set(self, row: 'md_row.TableRow',
@@ -84,9 +85,9 @@ class ColumnType(abc.ABC):
         """
         Validates that the item being set is valid.
         This is called by the default ``on_set``.
-        
+
         :param row: The row being set.
-        :param value: The value to set. 
+        :param value: The value to set.
         :return: A bool indicating if this is valid or not.
         """
         return True
@@ -95,9 +96,9 @@ class ColumnType(abc.ABC):
                     value: typing.Any):
         """
         Stores a value in the row's storage table.
-        
+
         This is for internal usage only.
-        
+
         :param row: The row to store in.
         :param value: The value to store in the row.
         """
@@ -106,10 +107,10 @@ class ColumnType(abc.ABC):
     def on_set(self, row: 'md_row.TableRow', value: typing.Any) -> typing.Any:
         """
         Called when a value is a set on this column.
-        
+
         This is the default method - it will call :meth:`.ColumnType.validate_set` to validate the
         type before storing it. This is useful for simple column types.
-        
+
         :param row: The row this value is being set on.
         :param value: The value being set.
         """
@@ -124,7 +125,7 @@ class ColumnType(abc.ABC):
     def on_get(self, row: 'md_row.TableRow') -> typing.Any:
         """
         Called when a value is retrieved from this column.
-        
+
         :param row: The row that is being retrieved.
         :return: The value of the row's internal storage.
         """
@@ -142,8 +143,8 @@ class ColumnType(abc.ABC):
     def in_(self, *args) -> 'md_operators.In':
         """
         Returns an IN operator, checking if a value in this column is in a tuple of items.
-        
-        :param args: The items to check. 
+
+        :param args: The items to check.
         """
         if len(args) <= 0:
             raise ValueError("Must provide at least one argument to in_")
@@ -183,7 +184,7 @@ class String(ColumnType):
         """
         Returns a LIKE operator, checking if this column is LIKE another string.
 
-        :param other: The other string to check. 
+        :param other: The other string to check.
         """
         return md_operators.Like(self.column, other)
 
@@ -194,7 +195,7 @@ class String(ColumnType):
         .. warning::
             This is not supported in all DB backends.
 
-        :param other: The other string to check. 
+        :param other: The other string to check.
         """
         if self.column.table._bind.dialect.has_ilike:
             return md_operators.ILike(self.column, other)
@@ -204,12 +205,12 @@ class String(ColumnType):
 
 class Text(String):
     """
-    Represents a TEXT type.  
+    Represents a TEXT type.
     TEXT type columns are very similar to String type objects, except that they have no size limit.
-    
+
     .. note::
         This is preferable to the String type in some databases.
-        
+
     .. warning::
         This is deprecated in MSSQL.
     """
@@ -237,7 +238,7 @@ class Boolean(ColumnType):
 class Integer(ColumnType):
     """
     Represents an INTEGER type.
-    
+
     .. warning::
         This represents a 32-bit integer (2**31-1 to -2**32)
     """
@@ -280,3 +281,15 @@ class BigInt(Integer):
 
     def validate_set(self, row, value):
         return -9223372036854775808 < value < 9223372036854775807
+
+
+class Timestamp(ColumnType):
+    """
+    Represents a TIMESTAMP type.
+    """
+
+    def sql(self):
+        return "TIMESTAMP"
+
+    def validate_set(self, row, value):
+        return isinstance(value, datetime.datetime)


### PR DESCRIPTION
asyncpg supports conversion of datetime objects to TIMESTAMP, so that's good.