### PR TITLE
Use io.StringIO for query building

### DIFF
--- a/asyncqlio/orm/schema/column.py
+++ b/asyncqlio/orm/schema/column.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import logging
 import typing
+import io
 
 from cached_property import cached_property
 
@@ -206,20 +207,23 @@ class Column(object):
         """
         Gets the DDL SQL for this column.
         """
-        base = "{} {}".format(self.name, self.type.sql())
+        base = io.StringIO()
+        base.write(self.name)
+        base.write(" ")
+        base.write(self.type.sql())
         if self.nullable:
-            base += " NULL"
+            base.write(" NULL")
         else:
-            base += " NOT NULL"
+            base.write(" NOT NULL")
 
         if self.unique:
-            base += " UNIQUE"
+            base.write(" UNIQUE")
 
         if self.foreign_key is not None:
             fk = self.foreign_key._ddl_split_fk()
-            base += " REFERENCES {0} ({1})".format(*fk)
+            base.write(" REFERENCES {0} ({1})".format(*fk))
 
-        return base
+        return base.getvalue()
 
     # Operators
 

--- a/asyncqlio/orm/schema/relationship.py
+++ b/asyncqlio/orm/schema/relationship.py
@@ -2,6 +2,7 @@
 Relationship helpers.
 """
 import typing
+import io
 
 from cached_property import cached_property
 
@@ -203,8 +204,11 @@ class Relationship(object):
 
         """
         # TODO: Maybe customize join types?
-        fmt = "LEFT OUTER JOIN {} {} ".format(self.foreign_table.alias_table.__quoted_name__,
-                                              self.foreign_table.__quoted_name__)
+        fmt = io.StringIO()
+        fmt.write("LEFT OUTER JOIN ")
+        fmt.write(self.foreign_table.alias_table.__quoted_name__)
+        fmt.write(" ")
+        fmt.write(self.foreign_table.__quoted_name__)
 
         # explanation
         # if parent is None, we can assume we're the first in the chain
@@ -218,9 +222,12 @@ class Relationship(object):
             left = self.our_column.quoted_fullname_with_table(self.owner_table)
 
         right = self.foreign_column.quoted_fullname_with_table(self.foreign_table)
-        fmt += 'ON {} = {}'.format(left, right)
+        fmt.write('ON ')
+        fmt.write(left)
+        fmt.write(' = ')
+        fmt.write(right)
 
-        return fmt
+        return fmt.getvalue()
 
     # right-wing logic
     @cached_property

--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -1,4 +1,5 @@
 import collections
+import io
 import itertools
 import logging
 import sys
@@ -520,7 +521,8 @@ class Table(metaclass=TableMeta, register=False):
         if self._session is None:
             self._session = session
 
-        q = "INSERT INTO {} ".format(self.table.__quoted_name__)
+        q = io.StringIO()
+        q.write("INSERT INTO {} ".format(self.table.__quoted_name__))
         params = {}
         column_names = []
         sql_params = []
@@ -539,9 +541,9 @@ class Table(metaclass=TableMeta, register=False):
                 params[name] = value
                 sql_params.append(param_name)
 
-        q += "({}) ".format(", ".join(column_names))
-        q += "VALUES "
-        q += "({}) ".format(", ".join(sql_params))
+        q.write("({}) ".format(", ".join(column_names)))
+        q.write("VALUES ")
+        q.write("({}) ".format(", ".join(sql_params)))
         # check if we support RETURNS
         if session.bind.dialect.has_returns:
             columns_to_get = []
@@ -551,10 +553,10 @@ class Table(metaclass=TableMeta, register=False):
                 columns_to_get.append(column)
 
             to_return = ", ".join(column.quoted_name for column in columns_to_get)
-            q += " RETURNING {}".format(to_return)
+            q.write(" RETURNING {}".format(to_return))
 
-        q += ";"
-        return q, params
+        q.write(";")
+        return q.getvalue(), params
 
     def _get_update_sql(self, emitter: typing.Callable[[], str], session: 'md_session.Session'):
         """
@@ -564,7 +566,8 @@ class Table(metaclass=TableMeta, register=False):
             self._session = session
 
         params = {}
-        base_query = "UPDATE {} SET ".format(self.table.__quoted_name__)
+        base_query = io.StringIO()
+        base_query.write("UPDATE {} SET ".format(self.table.__quoted_name__))
         # the params to "set"
         sets = []
 
@@ -590,7 +593,7 @@ class Table(metaclass=TableMeta, register=False):
         if not sets:
             return None, None
 
-        base_query += ", ".join(sets)
+        base_query.write(", ".join(sets))
 
         wheres = []
         for col in self.table.primary_key.columns:
@@ -601,9 +604,9 @@ class Table(metaclass=TableMeta, register=False):
             params[p] = history[col]["old"]
             wheres.append("{} = {}".format(col.quoted_name, session.bind.emit_param(p)))
 
-        base_query += " WHERE ({});".format(" AND ".join(wheres))
+        base_query.write(" WHERE ({});".format(" AND ".join(wheres)))
 
-        return base_query, params
+        return base_query.getvalue(), params
 
     def _get_delete_sql(self, emitter: typing.Callable[[], str], session: 'md_session.Session') \
             -> typing.Tuple[str, typing.Any]:
@@ -613,7 +616,8 @@ class Table(metaclass=TableMeta, register=False):
         if self._session is None:
             self._session = session
 
-        query = "DELETE FROM {} ".format(self.table.__quoted_name__)
+        query = io.StringIO()
+        query.write("DELETE FROM {} ".format(self.table.__quoted_name__))
         # generate the where clauses
         wheres = []
         params = {}
@@ -624,8 +628,8 @@ class Table(metaclass=TableMeta, register=False):
             params[name] = value
             wheres.append("{} = {}".format(col.quoted_fullname, session.bind.emit_param(name)))
 
-        query += "WHERE ({}) ".format(" AND ".join(wheres))
-        return query, params
+        query.write("WHERE ({}) ".format(" AND ".join(wheres)))
+        return query.getvalue(), params
 
     # value loading methods
     def _resolve_item(self, name: str):


### PR DESCRIPTION
Using io.StringIO.write instead of str.__iadd__ is faster and more memory efficient, especially for larger numbers of concatenations. This can be significant if an individual wishes to do large bulk updates, inserts, etc.