### PR TITLE
Add a space between table name and DROP TABLE

### DIFF
--- a/asyncqlio/orm/ddl/ddlsession.py
+++ b/asyncqlio/orm/ddl/ddlsession.py
@@ -70,7 +70,7 @@ class DDLSession(SessionBase):
         :param cascade: Should this drop cascade?
         """
         base = io.StringIO()
-        base.write("DROP TABLE")
+        base.write("DROP TABLE ")
         base.write(table_name)
         if cascade:
             base.write(" CASCADE;")


### PR DESCRIPTION
Oops. Sorry for making a bug, but on the bright side, fixing it myself.