### PR TITLE
Don't try to use NO_VALUE in the SQL

### DIFF
--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -615,7 +615,11 @@ class Table(metaclass=TableMeta, register=False):
             # then store it in the params counter
             # and build a new condition for the WHERE clause
             p = emitter()
-            params[p] = history[col]["old"]
+            old = history[col]["old"]
+            if old is not NO_VALUE:
+                params[p] = old
+            else:
+                params[p] = history[col]["new"]
             wheres.append("{} = {}".format(col.quoted_name, session.bind.emit_param(p)))
 
         base_query.write(" WHERE ({});".format(" AND ".join(wheres)))


### PR DESCRIPTION
This fixes a problem with calling ```Session.merge``` where it would inject the repr of ```NO_VALUE``` into the generated SQL statement.