### PR TITLE
Session test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Run tests via tox
           command: |
-            tox -e py35-postgres_asyncpg,py36-postgres_asyncpg
+            tox -e py36-postgres_asyncpg
 
 workflows:
   version: 2

--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -615,7 +615,11 @@ class Table(metaclass=TableMeta, register=False):
             # then store it in the params counter
             # and build a new condition for the WHERE clause
             p = emitter()
-            params[p] = history[col]["old"]
+            old = history[col]["old"]
+            if old is not NO_VALUE:
+                params[p] = old
+            else:
+                params[p] = history[col]["new"]
             wheres.append("{} = {}".format(col.quoted_name, session.bind.emit_param(p)))
 
         base_query.write(" WHERE ({});".format(" AND ".join(wheres)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,19 +7,37 @@ import os
 import pytest
 
 from asyncqlio import DatabaseInterface
+from asyncqlio.orm.schema.table import table_base, Table
+from asyncqlio.orm.schema.column import Column
+from asyncqlio.orm.schema.types import Integer, Text
 
-# set the iface as a global so it can be closed later
+# global so it can be accessed in other fixtures
 iface = DatabaseInterface()
 
 
 @pytest.fixture(scope='module')
 async def db() -> DatabaseInterface:
     await iface.connect(dsn=os.environ["ASQL_DSN"])
-    return iface
+    yield iface
+    await iface.close()
+
+
+@pytest.fixture(scope="module")
+async def table() -> Table:
+    class Test(table_base()):
+        id = Column(Integer(), primary_key=True)
+        name = Column(Text())
+        email = Column(Text())
+    async with iface.get_ddl_session() as session:
+        await session.create_table(Test.__tablename__,
+                                   *Test.iter_columns())
+    iface.bind_tables(Test)
+    yield Test
+    async with iface.get_ddl_session() as session:
+        await session.drop_table(Test.__tablename__)
 
 
 # override for a module scope
 @pytest.fixture(scope="module")
 def event_loop():
     return asyncio.get_event_loop()
-

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,81 @@
+"""
+Tests methods of Session.
+"""
+
+import pytest
+
+from asyncqlio import DatabaseInterface
+
+from asyncqlio.orm.schema.table import Table
+
+# mark all test_ functions as coroutines
+pytestmark = pytest.mark.asyncio
+
+kwargs = {
+    "name": "test",
+    "email": "test@example.com",
+}
+
+
+async def test_insert(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        await sess.insert.rows(*(table(id=i, **kwargs) for i in range(50)))
+
+
+async def test_fetch(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        res = await sess.fetch('select * from {}'.format(table.__tablename__))
+    for attr, value in kwargs.items():
+        assert res[attr] == value
+
+
+async def test_rollback(db: DatabaseInterface, table: Table):
+    sess = db.get_session()
+    await sess.start()
+    await sess.execute('delete from {} where true'.format(table.__tablename__))
+    await sess.rollback()
+    res = await sess.execute('select count(*) from test')
+    assert res == "SELECT 1"
+    await sess.close()
+
+
+async def test_select(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        res = await sess.select(table).where(table.id == 1).first()
+    for attr, value in kwargs.items():
+        assert getattr(res, attr, object()) == value
+
+
+async def test_update(db: DatabaseInterface, table: Table):
+    name = "test2"
+    async with db.get_session() as sess:
+        await sess.update(table).set(table.name, name).where(table.id > 10)
+    async with db.get_session() as sess:
+        results = await sess.select(table).where(table.id > 10).all()
+        async for result in results:
+            assert result.name == name
+
+
+async def test_merge(db: DatabaseInterface, table: Table):
+    id_ = 100
+    async with db.get_session() as sess:
+        await sess.execute("insert into {} values ({}, 'test', '')"
+                           .format(table.__tablename__, id_))
+    async with db.get_session() as sess:
+        await sess.merge(table(id=id_))
+
+
+async def test_delete(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        await sess.delete(table).where(table.id == 1)
+    async with db.get_session() as sess:
+        res = await sess.select(table).first()
+    assert res.id != 1
+
+
+async def test_truncate(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        await sess.truncate(table)
+    async with db.get_session() as sess:
+        res = await sess.select(table).first()
+    assert res is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}-{postgres_asyncpg,mysql_aiomysql}
+envlist = py{36}-{postgres_asyncpg,mysql_aiomysql}
 
 [testenv]
 passenv = ASQL_DSN


### PR DESCRIPTION
The reason to remove 3.5 from the test suite is so we can cleanup the ```DatabaseInterface``` after the tests are done, using an asynchronous generator function as a context manager thanks to pytest's nice fixtures.