### PR TITLE
Export Index and the new types

### DIFF
--- a/asyncqlio/__init__.py
+++ b/asyncqlio/__init__.py
@@ -35,8 +35,10 @@ from asyncqlio.exc import *
 from asyncqlio.orm.inspection import get_pk, get_row_history, get_row_session
 # orm
 from asyncqlio.orm.schema.column import Column
+from asyncqlio.orm.schema.index import Index
 from asyncqlio.orm.schema.relationship import ForeignKey, Relationship
 from asyncqlio.orm.schema.table import Table, table_base
-from asyncqlio.orm.schema.types import BigInt, Boolean, ColumnType, Integer, SmallInt, String, Text, \
-    Timestamp  # int types; misc; string types; dt types
+# int types; misc; string types; dt types
+from asyncqlio.orm.schema.types import BigInt, BigSerial, Boolean, ColumnType, Integer, Real, \
+     Serial, SmallInt, SmallSerial, String, Text, Timestamp
 from asyncqlio.orm.session import Session


### PR DESCRIPTION
This makes it possible to do `from asyncqlio import Index`, instead of `from asyncqlio.orm.schema.index import Index`, and `from asyncqlio import Serial` instead of `from asyncqlio.orm.schema.types import Serial`,

This should be all the classes that needed to be exported.