### PR TITLE
Upsert changes

### DIFF
--- a/asyncqlio/backends/mysql/__init__.py
+++ b/asyncqlio/backends/mysql/__init__.py
@@ -70,15 +70,15 @@ class MysqlDialect(BaseDialect):
     def get_upsert_sql(self, table_name, *, on_conflict_update=True):
         sql = io.StringIO()
         params = {"insert"}
-        sql.write("INSERT INTO ")
+        sql.write("INSERT ")
+        if not on_conflict_update:
+            sql.write("IGNORE ")
+        sql.write("INTO ")
         sql.write(table_name)
-        sql.write(" {insert} ON DUPLICATE KEY UPDATE ")
+        sql.write(" {insert}")
         if on_conflict_update:
             params.add("update")
-            sql.write("{update}")
-        else:
-            params.add("col")
-            sql.write("{col}={col}")
+            sql.write(" ON DUPLICATE KEY UPDATE {update}")
         sql.write(";")
         return sql.getvalue(), params
 

--- a/asyncqlio/orm/ddl/ddlsession.py
+++ b/asyncqlio/orm/ddl/ddlsession.py
@@ -200,8 +200,8 @@ class DDLSession(SessionBase):
 
         return await self.execute(fmt.getvalue())
 
-    async def create_index(self, table_name: str, column_name: str, name: str,
-                           *, unique: bool = False, if_not_exists: bool = False):
+    async def create_index(self, table_name: str, name: str, *column_names: str,
+                           unique: bool = False, if_not_exists: bool = False):
         """
         Creates an index on a column.
 
@@ -222,7 +222,7 @@ class DDLSession(SessionBase):
         fmt.write(" ON ")
         fmt.write(table_name)
         fmt.write("(")
-        fmt.write(column_name)
+        fmt.write(", ".join(column_names))
         fmt.write(");")
 
         return await self.execute(fmt.getvalue())

--- a/asyncqlio/orm/ddl/ddlsession.py
+++ b/asyncqlio/orm/ddl/ddlsession.py
@@ -206,8 +206,8 @@ class DDLSession(SessionBase):
         Creates an index on a column.
 
         :param table_name: The table with the column to be indexed.
-        :param column_name: The name of the column to be indexed.
         :param name: The name to give the index.
+        :param column_names: The names of the columns to be indexed.
         :param unique: Whether the index should enforce unique values.
         :param if_not_exists: Whether to use IF NOT EXISTS when making index.
         """

--- a/asyncqlio/orm/query.py
+++ b/asyncqlio/orm/query.py
@@ -526,9 +526,9 @@ class InsertQuery(BaseQuery):
         """
         Get an :class:`.UpsertQuery` to react upon a conflict.
 
-        :param column: The :class:`.Column` objects upon which to check for a conflict.
+        :param columns: The :class:`.Column` objects upon which to check for a conflict.
         """
-        return UpsertQuery(self.session, columns=columns, rows=self.rows_to_insert)
+        return UpsertQuery(self.session, *columns, rows=self.rows_to_insert)
 
     def generate_sql(self) -> typing.List[typing.Tuple[str, tuple]]:
         """
@@ -557,7 +557,7 @@ class UpsertQuery(InsertQuery):
     .. versionadded:: 0.2.0
     """
 
-    def __init__(self, sess: 'md_session.Session', *, columns: 'md_column.Column',
+    def __init__(self, sess: 'md_session.Session', *columns: 'md_column.Column',
                  rows: 'md_table.Table'):
         """
         :param sess: The :class:`.Session` this query is attached to.

--- a/asyncqlio/orm/schema/index.py
+++ b/asyncqlio/orm/schema/index.py
@@ -6,6 +6,8 @@ import io
 import logging
 import typing
 
+from cached_property import cached_property
+
 from asyncqlio.orm.schema import column as md_column, table as md_table
 
 logger = logging.getLogger(__name__)
@@ -79,6 +81,24 @@ class Index(object):
         if isinstance(self.table, str):
             return self.table
         return self.table.__tablename__
+
+    @cached_property
+    def quoted_name(self) -> str:
+        """
+        Gets the quoted name for this Index.
+
+        This returns the column name in "inde" format.
+        """
+        return r'"{}"'.format(self.name)
+
+    @cached_property
+    def quoted_fullname(self) -> str:
+        """
+        Gets the full quoted name for this index.
+
+        This returns the column name in "table"."index" format.
+        """
+        return r'"{}"."{}"'.format(self.table_name, self.name)
 
     @classmethod
     def with_name(cls, name: str, *args, **kwargs) -> 'Index':

--- a/asyncqlio/orm/schema/index.py
+++ b/asyncqlio/orm/schema/index.py
@@ -87,7 +87,7 @@ class Index(object):
         """
         Gets the quoted name for this Index.
 
-        This returns the column name in "inde" format.
+        This returns the column name in "index" format.
         """
         return r'"{}"'.format(self.name)
 

--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -847,10 +847,11 @@ class Table(metaclass=TableMeta, register=False):
 
         for fmt_param in needed_params:
             if fmt_param == "where":
-                param = emitter()
-                fmt_params["where"] = "{}={}".format(on_conflict_column.quoted_fullname,
-                                                     session.bind.emit_param(param))
-                params[param] = self.get_column_value(on_conflict_column)
+                fmt_params["where"] = " AND ".join("{}={}".format(col.quoted_fullname,
+                                                   session.bind.emit_param(param))
+                                                   for col in on_conflict_columns)
+                params.update({emitter(): self.get_column_value(col)
+                               for col in on_conflict_columns})
 
             elif fmt_param == "update":
                 fmt_params["update"] = ", ".join("{}={}".format(col.quoted_name, param)

--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -814,10 +814,10 @@ class Table(metaclass=TableMeta, register=False):
 
         return base_query.getvalue(), params
 
-    def _get_upsert_sql(self, emitter: typing.Callable[[], str], session: 'md_session.Session',
+    def _get_upsert_sql(self, emitter: 'typing.Callable[[], str]', session: 'md_session.Session',
                         *,
-                        update_columns: 'md_column.Column',
-                        on_conflict_columns: 'md_column.Column',
+                        update_columns: 'typing.List[md_column.Column]',
+                        on_conflict_columns: 'typing.List[md_column.Column]',
                         on_conflict_update: bool):
         """
         Gets the UPSERT sql for this row.
@@ -826,7 +826,7 @@ class Table(metaclass=TableMeta, register=False):
 
         :param session: The :class:`.Session` whose dialect to use when creating the SQL.
         :param update_columns: The :class:`.Column` objects to update on conflict.
-        :param on_conflict_column: The :class:`.Column` on which there may be a conflict.
+        :param on_conflict_columns: The :class:`.Column` objects on which there may be a conflict.
         :param on_conflict_update: Whether to update the table on conflict.
         """
         params = {}

--- a/asyncqlio/orm/schema/table.py
+++ b/asyncqlio/orm/schema/table.py
@@ -815,8 +815,9 @@ class Table(metaclass=TableMeta, register=False):
         return base_query.getvalue(), params
 
     def _get_upsert_sql(self, emitter: typing.Callable[[], str], session: 'md_session.Session',
-                        *update_columns: 'md_column.Column',
-                        on_conflict_column: 'md_column.Column',
+                        *,
+                        update_columns: 'md_column.Column',
+                        on_conflict_columns: 'md_column.Column',
                         on_conflict_update: bool):
         """
         Gets the UPSERT sql for this row.
@@ -866,7 +867,8 @@ class Table(metaclass=TableMeta, register=False):
                 )
 
             elif fmt_param == "col":
-                fmt_params["col"] = on_conflict_column.quoted_name
+                names = ", ".join(col.quoted_name for col in on_conflict_columns)
+                fmt_params["col"] = names
 
             else:
                 raise RuntimeError("Driver passed an invalid format specification.")

--- a/asyncqlio/orm/session.py
+++ b/asyncqlio/orm/session.py
@@ -351,7 +351,7 @@ class Session(SessionBase):
             returned_row = await cur.fetch_row()
 
             # if we have returns, we can store the column values directly
-            if self.bind.dialect.has_returns:
+            if self.bind.dialect.has_returns and returned_row is not None:
                 for colname, value in returned_row.items():
                     column = row.table.get_column(colname)
                     if column is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from asyncqlio import DatabaseInterface
 from asyncqlio.orm.schema.table import table_base, Table
 from asyncqlio.orm.schema.column import Column
-from asyncqlio.orm.schema.types import Integer, Text
+from asyncqlio.orm.schema.types import Integer, String
 
 
 # global so it can be accessed in other fixtures
@@ -27,8 +27,8 @@ async def db() -> DatabaseInterface:
 async def table() -> Table:
     class Test(table_base()):
         id = Column(Integer(), primary_key=True)
-        name = Column(Text())
-        email = Column(Text())
+        name = Column(String(64))
+        email = Column(String(64))
     async with iface.get_ddl_session() as session:
         await session.create_table(Test.__tablename__,
                                    *Test.iter_columns())

--- a/tests/test_1ddl.py
+++ b/tests/test_1ddl.py
@@ -74,7 +74,7 @@ async def test_create_index(db: DatabaseInterface):
     else:
         num_indexes = 2
     async with db.get_ddl_session() as sess:
-        await sess.create_index(table_name, "name", "index_name")
+        await sess.create_index(table_name, "index_name", "name")
     assert await get_num_indexes(db) == num_indexes
 
 
@@ -84,7 +84,7 @@ async def test_create_unique_index(db: DatabaseInterface):
     else:
         num_indexes = 3
     async with db.get_ddl_session() as sess:
-        await sess.create_index(table_name, "age", "index_age", unique=True)
+        await sess.create_index(table_name, "index_age", "age", unique=True)
     assert await get_num_indexes(db) == num_indexes
     fmt = "insert into {} values ({{}}, 'test', 10);".format(table_name)
     async with db.get_session() as sess:

--- a/tests/test_3session.py
+++ b/tests/test_3session.py
@@ -20,8 +20,10 @@ async def test_insert(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
         name = kwargs["name"]
         email = kwargs["email"]
-        await sess.insert.rows(*(table(id=i, name=name.format(i), email=email.format(i))
-                                 for i in range(50)))
+        rows = []
+        for i in range(50):
+            rows.append(table(id=i, name=name.format(i), email=email.format(i)))
+        await sess.insert.rows(*rows)
 
 
 async def test_fetch(db: DatabaseInterface, table: Table):

--- a/tests/test_3session.py
+++ b/tests/test_3session.py
@@ -11,21 +11,24 @@ from asyncqlio.orm.schema.table import Table
 pytestmark = pytest.mark.asyncio
 
 kwargs = {
-    "name": "test",
-    "email": "test@example.com",
+    "name": "test{}",
+    "email": "test{}@example.com",
 }
 
 
 async def test_insert(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
-        await sess.insert.rows(*(table(id=i, **kwargs) for i in range(50)))
+        name = kwargs["name"]
+        email = kwargs["email"]
+        await sess.insert.rows(*(table(id=i, name=name.format(i), email=email.format(i))
+                                 for i in range(50)))
 
 
 async def test_fetch(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
         res = await sess.fetch('select * from {}'.format(table.__tablename__))
     for attr, value in kwargs.items():
-        assert res[attr] == value
+        assert res[attr] == value.format(res["id"])
 
 
 async def test_rollback(db: DatabaseInterface, table: Table):
@@ -45,7 +48,7 @@ async def test_select(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
         res = await sess.select(table).where(table.id == 1).first()
     for attr, value in kwargs.items():
-        assert getattr(res, attr, object()) == value
+        assert getattr(res, attr, object()) == value.format(res.id)
 
 
 async def test_update(db: DatabaseInterface, table: Table):
@@ -69,6 +72,20 @@ async def test_upsert(db: DatabaseInterface, table: Table):
     assert table.email != "notupdated"
 
 
+async def test_upsert_multiple_constriants(db: DatabaseInterface, table: Table):
+    idx_name = "{}_email_idx".format(table.__tablename__)
+    async with db.get_ddl_session() as sess:
+        await sess.create_index(table.__tablename__, idx_name, "email", "name", unique=True)
+    for i in range(51, 53):
+        async with db.get_session() as sess:
+            query = sess.insert.rows(table(id=51, name="test1", email="test1@example.com"))
+            query = query.on_conflict(table.name, table.email).nothing()
+            await query.run()
+    async with db.get_session() as sess:
+        res = await sess.select(table).where(table.id == 52).first()
+    assert res is None
+
+
 async def test_merge(db: DatabaseInterface, table: Table):
     id_ = 100
     async with db.get_session() as sess:
@@ -82,8 +99,8 @@ async def test_delete(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
         await sess.delete(table).where(table.id == 1)
     async with db.get_session() as sess:
-        res = await sess.select(table).first()
-    assert res.id != 1
+        res = await sess.select(table).where(table.id == 1).first()
+    assert res is None
 
 
 async def test_truncate(db: DatabaseInterface, table: Table):


### PR DESCRIPTION
These changes allow you to use multiple columns as conflicts in an upsert, provided such a constraint exists on the table. It also makes some minor changes to MySql's upsert SQL generation, and gives ```Index``` objects some quoted name related properties.