### PR TITLE
Add support for Numeric types

### DIFF
--- a/asyncqlio/__init__.py
+++ b/asyncqlio/__init__.py
@@ -39,6 +39,6 @@ from asyncqlio.orm.schema.index import Index
 from asyncqlio.orm.schema.relationship import ForeignKey, Relationship
 from asyncqlio.orm.schema.table import Table, table_base
 # int types; misc; string types; dt types
-from asyncqlio.orm.schema.types import BigInt, BigSerial, Boolean, ColumnType, Integer, Real, \
-     Serial, SmallInt, SmallSerial, String, Text, Timestamp
+from asyncqlio.orm.schema.types import BigInt, BigSerial, Boolean, ColumnType, Integer, Numeric, \
+     Real, Serial, SmallInt, SmallSerial, String, Text, Timestamp
 from asyncqlio.orm.session import Session

--- a/asyncqlio/backends/mysql/__init__.py
+++ b/asyncqlio/backends/mysql/__init__.py
@@ -108,6 +108,10 @@ class MysqlDialect(BaseDialect):
                 real_type = md_types.Real
             elif mysql_type == "timestamp":
                 real_type = md_types.Timestamp
+            elif mysql_type == "double":
+                real_type = md_types.Numeric
+            elif mysql_type == "decimal":
+                real_type = md_types.Numeric
             else:
                 raise DatabaseException("Cannot parse type {}".format(mysql_type))
 

--- a/asyncqlio/backends/postgresql/__init__.py
+++ b/asyncqlio/backends/postgresql/__init__.py
@@ -135,6 +135,10 @@ FROM information_schema.columns
                 real_type = md_types.Real
             elif psql_type.startswith("timestamp"):
                 real_type = md_types.Timestamp
+            elif psql_type == "decimal":
+                real_type = md_types.Numeric
+            elif psql_type == "numeric":
+                real_type = md_types.Numeric
             else:
                 raise DatabaseException("Cannot parse type {}".format(psql_type))
 

--- a/asyncqlio/backends/sqlite3/__init__.py
+++ b/asyncqlio/backends/sqlite3/__init__.py
@@ -16,6 +16,11 @@ DEFAULT_CONNECTOR = "sqlite3"
 find_col_expr = re.compile(r"\((.*)\)")
 
 
+def _parse_numeric_params(t):
+    m = re.search('.*\(([0-9]+)(?:,([0-9]+))?\)', t)
+    return [int(v) if v is not None else 0 for v in m.groups()]
+
+
 class Sqlite3Dialect(BaseDialect):
     """
     The dialect for sqlite3.
@@ -106,6 +111,10 @@ class Sqlite3Dialect(BaseDialect):
                 real_type = md_types.Real
             elif psql_type == "TIMESTAMP":
                 real_type = md_types.Timestamp
+            elif psql_type.startswith("NUMERIC"):
+                real_type = md_types.Numeric(*_parse_numeric_params(psql_type)[1:])
+            elif psql_type.startswith("DECIMAL"):
+                real_type = md_types.Numeric(*_parse_numeric_params(psql_type)[1:])
             else:
                 raise DatabaseException("Cannot parse type {}".format(psql_type))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,11 @@ import pytest
 from asyncqlio import DatabaseInterface
 from asyncqlio.orm.schema.table import table_base, Table
 from asyncqlio.orm.schema.column import Column
-from asyncqlio.orm.schema.types import Integer, String
+from asyncqlio.orm.schema.types import (
+    Integer,
+    String,
+    Numeric,
+)
 
 
 # global so it can be accessed in other fixtures
@@ -29,6 +33,8 @@ async def table() -> Table:
         id = Column(Integer(), primary_key=True)
         name = Column(String(64))
         email = Column(String(64))
+        lat = Column(Numeric(5, 3), default=0)
+        lon = Column(Numeric(5, 3, False), default=0)
     async with iface.get_ddl_session() as session:
         await session.create_table(Test.__tablename__,
                                    *Test.iter_columns())

--- a/tests/test_2table.py
+++ b/tests/test_2table.py
@@ -11,7 +11,13 @@ from asyncqlio.orm.schema.column import Column
 from asyncqlio.orm.schema.index import Index
 from asyncqlio.orm.schema.relationship import Relationship, ForeignKey
 from asyncqlio.orm.schema.table import table_base as table_base
-from asyncqlio.orm.schema.types import Integer, Text, String
+from asyncqlio.orm.schema.types import (
+    Integer,
+    Text,
+    String,
+    Numeric,
+    Timestamp,
+)
 
 # mark all test_ functions as coroutines
 pytestmark = pytest.mark.asyncio
@@ -23,6 +29,9 @@ person_body = '''class Person(Table):
     ssn = Column(Integer(), unique=True)
     name = Column(String(128))
     age = Column(Integer())
+    lat = Column(Numeric(5, 2))
+    lon = Column(Numeric(5))
+    created = Column(Timestamp())
     person_name_idx = Index(name)
     person_age_idx = Index(age)
     cars = Relationship(left="Person.id", right="Car.owner_id")

--- a/tests/test_3session.py
+++ b/tests/test_3session.py
@@ -91,7 +91,7 @@ async def test_upsert_multiple_constriants(db: DatabaseInterface, table: Table):
 async def test_merge(db: DatabaseInterface, table: Table):
     id_ = 100
     async with db.get_session() as sess:
-        await sess.execute("insert into {} values ({}, 'test', '')"
+        await sess.execute("insert into {} values ({}, 'test', '', 0, 0)"
                            .format(table.__tablename__, id_))
     async with db.get_session() as sess:
         await sess.merge(table(id=id_))
@@ -111,3 +111,16 @@ async def test_truncate(db: DatabaseInterface, table: Table):
     async with db.get_session() as sess:
         res = await sess.select(table).first()
     assert res is None
+
+
+async def test_numeric_decimal(db: DatabaseInterface, table: Table):
+    async with db.get_session() as sess:
+        query = sess.insert.rows(table(id=110, name="numeric", email="", lat=12.010, lon=12.010))
+        await query.run()
+    async with db.get_session() as sess:
+        res = await sess.select(table).where(table.id == 110).first()
+
+    import decimal
+
+    assert str(res.lat) == "12.010"
+    assert str(res.lon) == "12.01"


### PR DESCRIPTION
First pass adding a Numeric type for decimal, numeric, double types in SQLite, PostgreSQL, MySQL (#44). This works as expected with the following test script:

```sql
CREATE TABLE `camps` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `lat` decimal(12,8) NOT NULL DEFAULT '0.00000000',
  `lon` decimal(12,8) NOT NULL DEFAULT '0.00000000',
  PRIMARY KEY (`id`),
  UNIQUE KEY `id_UNIQUE` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;

INSERT INTO `camps` (`lat`, `lon`) VALUES (11.0012, 11.0012);
```

```python
import asyncio
import os

from asyncqlio import (
    table_base,
    Column,
    Integer,
    Numeric,
    DatabaseInterface,
)


Table = table_base()
db = DatabaseInterface(os.environ.get('ASQL_DSN'))


class Camp(Table, table_name='camps'):
    id = Column(Integer, primary_key=True, unique=True)
    lat = Column(Numeric(12, 8), nullable=False)
    lon = Column(Numeric(12, 8, asdecimal=False), nullable=False)


async def test():
    await db.connect()
    async with db.get_session() as sess:
        u = await sess.select(Camp).where(Camp.id == 1).first()
    print(u)
    print(u.lat)
    print(u.lon)
    print(type(u.lat))
    print(type(u.lon))

loop = asyncio.get_event_loop()
loop.run_until_complete(test())
```

Results:

```
<Camp id=1 lat=11.00120000 lon=11.00120000>
11.00120000
11.0012
<class 'decimal.Decimal'>
<class 'float'>
```

  